### PR TITLE
Manifest: Add shared=ipc  (opencpn/opencpn#3601)

### DIFF
--- a/org.opencpn.OpenCPN.yaml
+++ b/org.opencpn.OpenCPN.yaml
@@ -22,6 +22,7 @@ finish-args:
     - --socket=x11
     - --socket=pulseaudio
     - --filesystem=home
+    - --share=ipc
     - --share=network
     - --device=all
     - --allow=canbus
@@ -119,7 +120,7 @@ modules:
       buildsystem: cmake
       builddir: true
       config-opts:
-          - -DOCPN_RELEASE=2
+          - -DOCPN_RELEASE=3
           - -DOCPN_BUNDLE_DOCS=ON
           - -DOCPN_BUNDLE_TCDATA=ON
           - -DOCPN_CI_BUILD=ON


### PR DESCRIPTION
According to https://github.com/OpenCPN/OpenCPN/issues/3601, KDE on X11 reveals a missing share=ipc in the manifest.

Documentation says that while ipc is not strictly required for X11, omitting it comes with a performance penalty. Let's thus enable it for now, a large part of  the user base is still on X11.