### PR TITLE
Let some system D-Bus events pass through

### DIFF
--- a/org.opencpn.OpenCPN.yaml
+++ b/org.opencpn.OpenCPN.yaml
@@ -26,6 +26,9 @@ finish-args:
     - --share=network
     - --device=all
     - --allow=canbus
+    - --system-talk-name=org.freedesktop.systemd1
+    - --system-talk-name=org.freedesktop.login1
+
 
 add-extensions:
     org.opencpn.OpenCPN.Plugin:


### PR DESCRIPTION
We listen for org.freedesktop.systemd1 D-bus events in order to handle USB devices which are inserted or ejected in the connection edit dialog. Likewise, we listens to org.freedesktop.login1 in order to handle suspend and resume signals

Make sure these signals are actually accessible in the sandbox using the manifest finish-args configuration.