### PR TITLE
New patches (#4088, date string)

### DIFF
--- a/org.opencpn.OpenCPN.yaml
+++ b/org.opencpn.OpenCPN.yaml
@@ -174,3 +174,6 @@ modules:
           - type: patch
             paths:
               - patches/0002-flatpak-Add-a-shell-wrapper.patch
+              - patches/0003-Build-Don-t-use-march-native-4088.patch
+              - patches/0004-VERSION.cmake-Fix-date-string.patch
+

--- a/patches/0003-Build-Don-t-use-march-native-4088.patch
+++ b/patches/0003-Build-Don-t-use-march-native-4088.patch
@@ -1,0 +1,39 @@
+From: Alec Leamas <leamas.alec@gmail.com>
+Date: Sun, 11 Aug 2024 08:50:47 +0200
+Subject: Build: Don't use -march=native (#4088)
+
+Bug: https://github.com/OpenCPN/OpenCPN/issues/4088
+
+---
+ libs/mipmap/CMakeLists.txt              | 4 ++--
+ libs/mipmap/cmake/CompilerSupport.cmake | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/libs/mipmap/CMakeLists.txt b/libs/mipmap/CMakeLists.txt
+index cb1a185..4aa31cb 100644
+--- a/libs/mipmap/CMakeLists.txt
++++ b/libs/mipmap/CMakeLists.txt
+@@ -37,8 +37,8 @@ if( NOT QT_ANDROID)
+   if (NOT MSVC)
+       set_property(TARGET MIPMAP PROPERTY COMPILE_FLAGS "-fvisibility=hidden -O3")
+       if (NOT APPLE)
+-          set_source_files_properties(
+-            src/mipmap.c PROPERTIES COMPILE_FLAGS "-march=native")
++          # set_source_files_properties(
++          #   src/mipmap.c PROPERTIES COMPILE_FLAGS "-march=native")
+       endif()
+       if (HAVE_MSSE)
+           message(STATUS "mipmap SSE support enabled")
+diff --git a/libs/mipmap/cmake/CompilerSupport.cmake b/libs/mipmap/cmake/CompilerSupport.cmake
+index e02d8de..8a32876 100644
+--- a/libs/mipmap/cmake/CompilerSupport.cmake
++++ b/libs/mipmap/cmake/CompilerSupport.cmake
+@@ -12,7 +12,7 @@ if(HAVE_ARM_NEON)
+ endif()
+ 
+ #set(CMAKE_REQUIRED_INCLUDES /usr/lib/gcc/x86_64-redhat-linux/13/include/)
+-set(CMAKE_REQUIRED_FLAGS "-march=native")
++#set(CMAKE_REQUIRED_FLAGS "-march=native")
+ 
+ include(CheckCSourceCompiles)
+ check_c_source_compiles(

--- a/patches/0004-VERSION.cmake-Fix-date-string.patch
+++ b/patches/0004-VERSION.cmake-Fix-date-string.patch
@@ -1,0 +1,18 @@
+From: Alec Leamas <leamas.alec@gmail.com>
+Date: Sun, 11 Aug 2024 08:58:08 +0200
+Subject: VERSION.cmake: Fix date string
+
+---
+ VERSION.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/VERSION.cmake b/VERSION.cmake
+index 0115f00..bb47192 100644
+--- a/VERSION.cmake
++++ b/VERSION.cmake
+@@ -1,4 +1,4 @@
+ SET(VERSION_MAJOR "5")
+ SET(VERSION_MINOR "10")
+ SET(VERSION_PATCH "0")
+-SET(VERSION_DATE "2023-08-09")
++SET(VERSION_DATE "2024-08-09")


### PR DESCRIPTION
- Dont use -march=native  (#4088)
- Fix VERSION.cmake date string (2023 -> 2024)